### PR TITLE
Update Bundler to 2.7.2 for Ruby 3.4 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,10 +33,11 @@ GEM
       listen (~> 3.0)
     kramdown (1.17.0)
     liquid (4.0.1)
-    listen (3.1.5)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-      ruby_dep (~> 1.2)
+    listen (3.10.0)
+      logger
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     mercenary (0.3.6)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -45,7 +46,6 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     rouge (3.3.0)
-    ruby_dep (1.5.0)
     safe_yaml (1.0.4)
     sass (3.7.2)
       sass-listen (~> 4.0.0)
@@ -61,4 +61,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.16.1
+   2.7.2


### PR DESCRIPTION
Bundler 1.16.1 calls String#untaint which was removed in Ruby 3.4, causing the Netlify build to fail. Updated to Bundler 2.7.2 which is compatible with modern Ruby. Also updated listen from 3.1.5 to 3.10.0, removing the deprecated ruby_dep dependency.

https://claude.ai/code/session_01DMrGFEpekfcPN3aCcEaEYr