### PR TITLE
Add base64 gem for Ruby 3.4 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ source "https://rubygems.org"
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
 gem "jekyll", "~> 3.8"
+gem "base64"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    base64 (0.3.0)
     colorator (1.1.0)
     concurrent-ruby (1.1.4)
     em-websocket (0.5.1)
@@ -57,6 +58,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  base64
   jekyll (~> 3.8)
   tzinfo-data
 


### PR DESCRIPTION
In Ruby 3.4, base64 is a bundled gem and must be explicitly required. safe_yaml (used by Jekyll) calls require "base64" which fails unless the gem is declared in the Gemfile. Adding it directly fixes the Jekyll build failure on Netlify.

https://claude.ai/code/session_01DMrGFEpekfcPN3aCcEaEYr