### PR TITLE
Add kramdown-parser-gfm gem for Jekyll on Ruby 3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ source "https://rubygems.org"
 gem "jekyll", "~> 3.10"
 gem "base64"
 gem "bigdecimal"
+gem "kramdown-parser-gfm"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,8 @@ GEM
       listen (~> 3.0)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     liquid (4.0.4)
     listen (3.10.0)
       logger
@@ -88,6 +90,7 @@ DEPENDENCIES
   base64
   bigdecimal
   jekyll (~> 3.10)
+  kramdown-parser-gfm
   tzinfo-data
 
 BUNDLED WITH


### PR DESCRIPTION
## Summary

Adds `kramdown-parser-gfm` gem to fix the next Netlify build failure.

## Root cause

Jekyll 3.10 requires `kramdown-parser-gfm` for GitHub-Flavored Markdown conversion. It was not declared in the Gemfile, causing a dependency error during `jekyll build`.

## Test plan
- [ ] Netlify deploy succeeds after merging